### PR TITLE
Added @ prefix for replies to trigger notifications.

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -7,7 +7,7 @@ class Flowdock extends Adapter
 
   reply: (user, strings...) ->
     strings.forEach (str) =>
-      @send user, "#{user.name}: #{str}"
+      @send user, "@#{user.name}: #{str}"
 
   connect: ->
     ids = (flow.id for flow in @flows)


### PR DESCRIPTION
The Flowdock [Chat](https://www.flowdock.com/help/chat) allows to _Get your teammate's attention by mentioning their name [with and @ prefix] in your messages._ - obviously Hubot should follow this etiquette as well.
- This is likewise implemented in the HipChat adapter btw., see [Line 14 in hipchat.coffee](https://github.com/hipchat/hubot-hipchat/blob/2dd93afab97dd38f697beb4e6357052039279efc/src/hipchat.coffee#L14).
