### PR TITLE
Add the unique ID of the user to the user object attached to the message

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -15,6 +15,7 @@ class Flowdock extends Adapter
     @stream.on 'message', (message) =>
       return unless message.event == 'message'
       author =
+        id: message.user
         name: @userForId(message.user).name
         flow: message.flow
       return if @robot.name == author.name


### PR DESCRIPTION
This allows the bot to store it and make use of it in response to future messages
