### PR TITLE
Ignore case for robot name

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -18,7 +18,7 @@ class Flowdock extends Adapter
         id: message.user
         name: @userForId(message.user).name
         flow: message.flow
-      return if @robot.name == author.name
+      return if @robot.name.toLowerCase() == author.name.toLowerCase()
       @receive new TextMessage(author, message.content)
 
   run: ->


### PR DESCRIPTION
We ran into the problem of Hubot responding to himself, and I think #15 probably has the same issue.

The name of the robot should be case insensitive when checking to see if it's himself.
