### PR TITLE
Handle @username message style

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -19,7 +19,11 @@ class Flowdock extends Adapter
         name: @userForId(message.user).name
         flow: message.flow
       return if @robot.name == author.name
-      @receive new TextMessage(author, message.content)
+      # Reformat leading @mention name to be like "name: message" which is
+      # what hubot expects
+      regex = new RegExp("^@#{@robot.name}\\b", "i")
+      hubot_msg = message.content.replace(regex, "#{@robot.name}: ")
+      @receive new TextMessage(author, hubot_msg)
 
   run: ->
     @login_email    = process.env.HUBOT_FLOWDOCK_LOGIN_EMAIL


### PR DESCRIPTION
Hipchat's adapter handle @username style messaging

https://github.com/hipchat/hubot-hipchat/blob/master/src/hipchat.coffee#L121

Flowdock's should probably do the same since @message is such a popular style.
