### PR TITLE
Add support for commenting for reply instead of non-threaded messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "email": "team@flowdock.com"
   },
   "dependencies": {
-    "flowdock": "0.5.x"
+    "flowdock": "0.6.x"
   },
   "devDependencies": {
     "coffee-script": ">=1.2.0"


### PR DESCRIPTION
Commenting will now be the default action when `msg.send`ing, providing the needed info has been captured from the stream event.

Script authors can force a new message by modifying the response envelope: msg.envelope.newMessage = true; msg.send …

This requires the new comment method in node-flowdock 0.6

Fixes #39
