### PR TITLE
Update user data when user changes names

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -49,10 +49,16 @@ class Flowdock extends Adapter
     # hubot >=2.5.0: @robot.brain.userForId
     @robot.brain?.userForId?(id, data) || @userForId(id, data)
 
+  changeUserNick: (id, newNick) ->
+    if id of @robot.brain.data.users
+      @robot.brain.data.users[id].name = newNick
+
   connect: ->
     ids = (flow.id for flow in @flows)
     @stream = @bot.stream(ids, active: 'idle', user: 1)
     @stream.on 'message', (message) =>
+      if message.event == 'user-edit'
+        @changeUserNick(message.content.user.id, message.content.user.nick)
       return unless message.event in ['message', 'comment']
       if message.event == 'message'
         messageId = message.id


### PR DESCRIPTION
When a user changes his/her Flowdock account Nick, the only way to update the user data is to manually modify the users object. This affects scripts such as roles, karma, etc. that attach data to user objects based on the associated names. These changes add a check for the 'user-edit' stream event and remaps the user object in the brain.
