### PR TITLE
Added room to the data object created from the flows.

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -109,13 +109,12 @@ class Flowdock extends Adapter
       @flows = flows
       @flowsByParametrizedNames = {}
       for flow in flows
-        parametrizedName = "#{flow.organization.parameterized_name}/#{flow.parameterized_name}"
-        @flowsByParametrizedNames[parametrizedName] = flow
+        @flowsByParametrizedNames["#{flow.organization.parameterized_name}/#{flow.parameterized_name}"] = flow
         for user in flow.users
           data =
             id: user.id
             name: user.nick
-            room: parametrizedName
+            room: Date.now()
           @userFromId user.id, data
       @connect()
 


### PR DESCRIPTION
This allows updated nicks to get into the Hubot brain if the nick was changed while Hubot was offline.

The scenario is that while Hubot is offline for any reason, if someone changed a nick in flowdock it will never be caught.  When Hubot launches, it loads the brain which contains the last know collection of users.  When the flowdock adapter builds new data to send to updateFromId, if room is not set in that data object, it will not update any existing users. New users are added just fine, but existing users keep their old nick names and as such anything built around capturing data by name (like seen.coffee) will not capture data on the new nick, it will keep attributing it to the old nick. This is Not a Good Thing™

Now, I'm not entirely sure what the real purpose of the room key is in robot.brain.data.users, but by setting it, we ensure that updates are applied to existing users when Hubot starts. 

See: https://github.com/github/hubot/blob/master/src/brain.coffee#L109
