### PR TITLE
Update user nicks that are changed while hubot is offline

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -114,7 +114,9 @@ class Flowdock extends Adapter
           data =
             id: user.id
             name: user.nick
-          @userFromId user.id, data
+          savedUser = @userFromId user.id, data
+          if (savedUser.name != data.name)
+            @changeUserNick(savedUser.id, data.name)
       @connect()
 
     @bot


### PR DESCRIPTION
If anything, this adds a minimal amount of extra work to the launch process, but because robot.brain.userForId is abstract to the point that it only knows about user.id and options.room (for some odd reason), this puts the responsibility on the flowdock adapter to update the user's name if necessary.
