### PR TITLE
Emit a streaming event

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -102,6 +102,7 @@ class Flowdock extends Adapter
     @stream.on 'connected', =>
       @robot.logger.info('Flowdock: connected and streaming')
       @robot.logger.info('Flowdock: listening to flows:', (flow.name for flow in @joinedFlows()).join(', '))
+      @emit 'streaming', @stream
     @stream.on 'clientError', (error) => @robot.logger.error('Flowdock: client error:', error)
     @stream.on 'disconnected', => @robot.logger.info('Flowdock: disconnected')
     @stream.on 'reconnecting', => @robot.logger.info('Flowdock: reconnecting')


### PR DESCRIPTION
Hi my name is Charles, I'm a web app developer over at [VENTURE.co](https://www.venture.co). We use Flowdock for our internal chat and I have recently been implementing a Hubot in our chat. Your adapter was exceedingly easy to get started with and I'm really pleased with the support you have for chatbots.

I would like to propose emitting a `streaming` event. It would be emitted when the stream to Flowdock is connected and would include the stream itself as an argument. This would allow for the bot in question to respond to other Flowdock Messages, say an `activity` from a 3rd party integration, without needing to open a second stream.
