### PR TITLE
Fix reconnect on flow-add

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -106,11 +106,11 @@ class Flowdock extends Adapter
     @stream.on 'disconnected', => @robot.logger.info('Flowdock: disconnected')
     @stream.on 'reconnecting', => @robot.logger.info('Flowdock: reconnecting')
     @stream.on 'message', (message) =>
-      return if !message.content? || !message.event? || !message.id?
-      if message.event == 'user-edit' || message.event == 'backend.user.join'
-        @changeUserNick(message.content.user.id, message.content.user.nick)
       if @needsReconnect(message)
         @reconnect('Reloading flow list')
+      return if !message.content? || !message.event? || !message.id?
+      if message.event == 'user-edit' || message.event == 'backend.user.join'
+        @changeUserNick(message.content.user.id, message.content.user.nick)      
       return unless message.event in ['message', 'comment']
       return if @myId(message.user)
       return if String(message.user) in @ignores

--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -108,9 +108,11 @@ class Flowdock extends Adapter
     @stream.on 'message', (message) =>
       if @needsReconnect(message)
         @reconnect('Reloading flow list')
+      if (@myId(message.user) && message.event in ['backend.user.join', 'flow-add'])
+        @robot.emit "flow-add", { id: message.content.id, name: message.content.name }
       return if !message.content? || !message.event? || !message.id?
       if message.event == 'user-edit' || message.event == 'backend.user.join'
-        @changeUserNick(message.content.user.id, message.content.user.nick)      
+        @changeUserNick(message.content.user.id, message.content.user.nick)
       return unless message.event in ['message', 'comment']
       return if @myId(message.user)
       return if String(message.user) in @ignores

--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -106,14 +106,15 @@ class Flowdock extends Adapter
     @stream.on 'disconnected', => @robot.logger.info('Flowdock: disconnected')
     @stream.on 'reconnecting', => @robot.logger.info('Flowdock: reconnecting')
     @stream.on 'message', (message) =>
+      return if !message.content? || !message.event?
       if @needsReconnect(message)
         @reconnect('Reloading flow list')
       if (@myId(message.user) && message.event in ['backend.user.join', 'flow-add'])
         @robot.emit "flow-add", { id: message.content.id, name: message.content.name }
-      return if !message.content? || !message.event? || !message.id?
       if message.event == 'user-edit' || message.event == 'backend.user.join'
         @changeUserNick(message.content.user.id, message.content.user.nick)
       return unless message.event in ['message', 'comment']
+      return if !message.id?
       return if @myId(message.user)
       return if String(message.user) in @ignores
 


### PR DESCRIPTION
'flow-add' events don't seem to have an id property, so the on 'message' event is skipping out early.
The needsReconnect can safely be done before checking for the id property.
It's useful to be able to know when hubot has been added to a flow, so emit an event.