### PR TITLE
Move connected event to post-flow-join

### DIFF
--- a/src/flowdock.coffee
+++ b/src/flowdock.coffee
@@ -105,6 +105,7 @@ class Flowdock extends Adapter
     @stream.on 'connected', =>
       @robot.logger.info('Flowdock: connected and streaming')
       @robot.logger.info('Flowdock: listening to flows:', (flow.name for flow in @joinedFlows()).join(', '))
+      @emit 'connected'
     @stream.on 'clientError', (error) => @robot.logger.error('Flowdock: client error:', error)
     @stream.on 'disconnected', => @robot.logger.info('Flowdock: disconnected')
     @stream.on 'reconnecting', => @robot.logger.info('Flowdock: reconnecting')
@@ -175,8 +176,6 @@ class Flowdock extends Adapter
       @emit e
 
     @fetchFlowsAndConnect()
-
-    @emit 'connected'
 
   fetchFlowsAndConnect: ->
     @bot.flows (err, flows, res) =>


### PR DESCRIPTION
The `connected` event was being emitted after the Flowdock connection was
*initiated*, but that meant the event was dispatched before there was actually
a live connection to work with. This meant sending messages on connect, for
example, wouldn't work.

The `connected` event is now correctly dispatched once the connection to
Flowdock is fully established and authed, and all flows have been joined.